### PR TITLE
Apply cargo fmt + clippy baseline for Rust 1.96

### DIFF
--- a/wabba-protocol/src/hash.rs
+++ b/wabba-protocol/src/hash.rs
@@ -14,9 +14,8 @@ impl Hash {
         let hash_bytes = hash.to_le_bytes();
 
         // Format in base64
-        let hash_base64 = BASE64_STANDARD.encode(&hash_bytes);
 
-        hash_base64
+        BASE64_STANDARD.encode(hash_bytes)
     }
 
     /// Stream a file through xxhash64 without loading the whole file into

--- a/wabba-server/src/data_dir.rs
+++ b/wabba-server/src/data_dir.rs
@@ -10,14 +10,11 @@ impl DataDir {
             std::fs::create_dir_all(&path).unwrap();
         }
         if !path.is_dir() {
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Path is not a directory",
-            )));
+            return Err(Box::new(std::io::Error::other("Path is not a directory")));
         }
 
-        std::fs::create_dir_all(&path.join("Modlists")).unwrap();
-        std::fs::create_dir_all(&path.join("Downloads")).unwrap();
+        std::fs::create_dir_all(path.join("Modlists")).unwrap();
+        std::fs::create_dir_all(path.join("Downloads")).unwrap();
 
         Ok(DataDir(path))
     }

--- a/wabba-server/src/db/migrations.rs
+++ b/wabba-server/src/db/migrations.rs
@@ -56,7 +56,7 @@ pub fn migrate(mut conn: PooledConnection<SqliteConnectionManager>) -> Result<()
 
     migrations
         .to_latest(&mut conn)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     Ok(())
 }

--- a/wabba-server/src/db/mod_association.rs
+++ b/wabba-server/src/db/mod_association.rs
@@ -82,9 +82,7 @@ impl ModAssociation {
              ORDER BY filename",
         )?;
         let associations = stmt
-            .query_map(params![modlist_id], |row| {
-                Ok(ModAssociation::from_row(row)?)
-            })?
+            .query_map(params![modlist_id], ModAssociation::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(associations)
@@ -101,7 +99,7 @@ impl ModAssociation {
              ORDER BY modlist_id",
         )?;
         let associations = stmt
-            .query_map(params![mod_id], |row| Ok(ModAssociation::from_row(row)?))?
+            .query_map(params![mod_id], ModAssociation::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(associations)

--- a/wabba-server/src/db/mod_data.rs
+++ b/wabba-server/src/db/mod_data.rs
@@ -127,7 +127,7 @@ impl Mod {
             "SELECT id, disk_filename, size, xxhash64, lost_forever FROM \"mod\" ORDER BY disk_filename",
         )?;
         let mods = stmt
-            .query_map([], |row| Ok(Mod::from_row(row)?))?
+            .query_map([], Mod::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mods)
@@ -141,7 +141,7 @@ impl Mod {
             "SELECT id, disk_filename, size, xxhash64, lost_forever FROM \"mod\" WHERE disk_filename IS NULL",
         )?;
         let mods = stmt
-            .query_map([], |row| Ok(Mod::from_row(row)?))?
+            .query_map([], Mod::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mods)
@@ -159,7 +159,7 @@ impl Mod {
              ORDER BY \"mod\".disk_filename",
         )?;
         let mods = stmt
-            .query_map(params![modlist_id], |row| Ok(Mod::from_row(row)?))?
+            .query_map(params![modlist_id], Mod::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mods)
@@ -198,9 +198,9 @@ impl Mod {
 
         let new_value = !self.lost_forever;
         conn.prepare("UPDATE \"mod\" SET lost_forever = ?1 WHERE id = ?2")
-            .map_err(|e| ToggleLostForeverError::DatabaseError(e))?
+            .map_err(ToggleLostForeverError::DatabaseError)?
             .execute(params![new_value, self.id])
-            .map_err(|e| ToggleLostForeverError::DatabaseError(e))?;
+            .map_err(ToggleLostForeverError::DatabaseError)?;
 
         Ok(())
     }
@@ -217,7 +217,7 @@ impl Mod {
              ORDER BY modlist.name"
         )?;
         let modlists = stmt
-            .query_map(params![self.id], |row| Ok(Modlist::from_row(row)?))?
+            .query_map(params![self.id], Modlist::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(modlists)
@@ -247,9 +247,7 @@ impl Mod {
              ORDER BY id",
         )?;
         let mods = stmt
-            .query_map(params![disk_filename, exclude_id], |row| {
-                Ok(Mod::from_row(row)?)
-            })?
+            .query_map(params![disk_filename, exclude_id], Mod::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mods)

--- a/wabba-server/src/db/modlist.rs
+++ b/wabba-server/src/db/modlist.rs
@@ -87,7 +87,7 @@ impl Modlist {
     ) -> Result<Vec<Self>, rusqlite::Error> {
         let mut stmt = conn.prepare("SELECT id, filename, name, version, size, xxhash64, available, muted FROM modlist ORDER BY name, version DESC")?;
         let archives = stmt
-            .query_map([], |row| Ok(Modlist::from_row(row)?))?
+            .query_map([], Modlist::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(archives)
@@ -98,7 +98,7 @@ impl Modlist {
     ) -> Result<Vec<Self>, rusqlite::Error> {
         let mut stmt = conn.prepare("SELECT id, filename, name, version, size, xxhash64, available, muted FROM modlist WHERE muted = TRUE ORDER BY name, version DESC")?;
         let archives = stmt
-            .query_map([], |row| Ok(Modlist::from_row(row)?))?
+            .query_map([], Modlist::from_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(archives)

--- a/wabba-server/src/resources/bootstrap.rs
+++ b/wabba-server/src/resources/bootstrap.rs
@@ -24,7 +24,7 @@ fn bootstrap_modlists_impl(
         let file_name_os = modlist_file.file_name();
         let filename = file_name_os.to_str().unwrap();
         let hash = Hash::compute(&std::fs::read(&path).unwrap());
-        ingest_modlist(&filename, &hash, &path, &conn)?;
+        ingest_modlist(filename, &hash, &path, conn)?;
     }
 
     Ok(())
@@ -52,7 +52,7 @@ fn bootstrap_mods_impl(
             .expect("Failed to convert file name to string");
         log::info!("Processing mod file: {:?}", filename);
         let hash = Hash::compute(&std::fs::read(&path).expect("Failed to read mod file"));
-        ingest_mod(&filename, &hash, &path, &conn)?;
+        ingest_mod(filename, &hash, &path, conn)?;
     }
 
     Ok(())

--- a/wabba-server/src/resources/ingest.rs
+++ b/wabba-server/src/resources/ingest.rs
@@ -16,15 +16,15 @@ pub fn ingest_mod(
     path: &Path,
     conn: &PooledConnection<SqliteConnectionManager>,
 ) -> Result<(), actix_web::Error> {
-    let size = std::fs::metadata(&path).unwrap().len() as u64;
+    let size = std::fs::metadata(path).unwrap().len() as u64;
 
     // Check if file was in DB but unavailable - if so, mark as available; otherwise create new
-    match Mod::get_by_size_and_hash(size, hash, &conn)
+    match Mod::get_by_size_and_hash(size, hash, conn)
         .map_err(|e| actix_web::error::ErrorInternalServerError(format!("Database error: {}", e)))?
     {
         Some(stored_mod) => {
             log::info!("Mod present in db, setting disk filename");
-            stored_mod.set_disk_filename(filename, &conn).map_err(|e| {
+            stored_mod.set_disk_filename(filename, conn).map_err(|e| {
                 actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
             })?;
         }
@@ -34,10 +34,10 @@ pub fn ingest_mod(
             let mod_egg = ModEgg {
                 disk_filename: Some(filename.to_string()),
                 xxhash64: hash.to_string(),
-                size: size,
+                size,
             };
 
-            mod_egg.create(&conn).map_err(|e| {
+            mod_egg.create(conn).map_err(|e| {
                 actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
             })?;
         }
@@ -56,7 +56,7 @@ pub fn ingest_modlist(
     let metadata = WabbajackMetadata::load(path).expect("Failed to load Wabbajack metadata");
 
     // Check if modlist already exists - update if needed, otherwise create new
-    let modlist = match Modlist::get_by_filename(&filename, &conn)
+    let modlist = match Modlist::get_by_filename(filename, conn)
         .map_err(|e| actix_web::error::ErrorInternalServerError(format!("Database error: {}", e)))?
     {
         Some(existing) => {
@@ -68,11 +68,11 @@ pub fn ingest_modlist(
                 name: metadata.name.clone(),
                 version: metadata.version.clone(),
                 xxhash64: hash.to_string(),
-                size: size,
+                size,
                 available: true,
                 muted: existing.muted,
             };
-            updated.update(&conn).map_err(|e| {
+            updated.update(conn).map_err(|e| {
                 actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
             })?;
             updated
@@ -85,11 +85,11 @@ pub fn ingest_modlist(
                 name: metadata.name.clone(),
                 version: metadata.version.clone(),
                 xxhash64: hash.to_string(),
-                size: size,
+                size,
                 available: true,
             };
 
-            modlist_egg.create(&conn).map_err(|e| {
+            modlist_egg.create(conn).map_err(|e| {
                 actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
             })?
         }
@@ -100,10 +100,10 @@ pub fn ingest_modlist(
     // Associate required mods
     for archive in metadata.required_archives() {
         // Find or create the Mod entry (unique file identified by size + hash)
-        let mod_to_associate = match Mod::get_by_size_and_hash(archive.size, &archive.hash, &conn)
+        let mod_to_associate = match Mod::get_by_size_and_hash(archive.size, &archive.hash, conn)
             .map_err(|e| {
-            actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
-        })? {
+                actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
+            })? {
             Some(existing_mod) => existing_mod,
             None => {
                 // Create new mod entry
@@ -113,7 +113,7 @@ pub fn ingest_modlist(
                     size: archive.size,
                 };
 
-                let created_mod = mod_egg.create(&conn).map_err(|e| {
+                let created_mod = mod_egg.create(conn).map_err(|e| {
                     actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
                 })?;
 
@@ -124,7 +124,7 @@ pub fn ingest_modlist(
 
         // Create or update the ModAssociation with modlist-specific metadata
         // Check if association already exists
-        match ModAssociation::get_by_modlist_and_mod(modlist.id, mod_to_associate.id, &conn)
+        match ModAssociation::get_by_modlist_and_mod(modlist.id, mod_to_associate.id, conn)
             .map_err(|e| {
                 actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
             })? {
@@ -134,7 +134,7 @@ pub fn ingest_modlist(
                 existing_assoc.filename = archive.filename.clone();
                 existing_assoc.name = archive.name();
                 existing_assoc.version = archive.version();
-                existing_assoc.update(&conn).map_err(|e| {
+                existing_assoc.update(conn).map_err(|e| {
                     actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
                 })?;
                 log::info!("Updated mod association: {:#?}", existing_assoc);
@@ -150,7 +150,7 @@ pub fn ingest_modlist(
                 };
 
                 // Create new association
-                association_egg.create(&conn).map_err(|e| {
+                association_egg.create(conn).map_err(|e| {
                     actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
                 })?;
                 log::info!("Created new mod association");

--- a/wabba-server/src/resources/mod.rs
+++ b/wabba-server/src/resources/mod.rs
@@ -159,9 +159,9 @@ fn check_hash<A: ArchiveType>(
         }
     };
 
-    match A::get_by_hash(hash, conn).map_err(|e| {
-        actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
-    })? {
+    match A::get_by_hash(hash, conn)
+        .map_err(|e| actix_web::error::ErrorInternalServerError(format!("Database error: {}", e)))?
+    {
         Some(archive) if archive.is_available() => Ok(HttpResponse::NotModified().finish()),
         _ => Ok(HttpResponse::Ok().finish()),
     }

--- a/wabba-server/src/web/details_page.rs
+++ b/wabba-server/src/web/details_page.rs
@@ -977,14 +977,10 @@ pub async fn delete_mod(
 
     if let Some(disk_filename) = &mod_item.disk_filename {
         let file_path = data_dir.get_mod_path(disk_filename);
-        if file_path.exists() {
-            if let Err(e) = std::fs::remove_file(&file_path) {
-                log::warn!(
-                    "Failed to remove mod file {}: {}",
-                    file_path.display(),
-                    e
-                );
-            }
+        if file_path.exists()
+            && let Err(e) = std::fs::remove_file(&file_path)
+        {
+            log::warn!("Failed to remove mod file {}: {}", file_path.display(), e);
         }
     }
 
@@ -1022,14 +1018,14 @@ pub async fn delete_modlist(
         .ok_or_else(|| actix_web::error::ErrorNotFound("Modlist not found"))?;
 
     let file_path = data_dir.get_modlist_path(&modlist.filename);
-    if file_path.exists() {
-        if let Err(e) = std::fs::remove_file(&file_path) {
-            log::warn!(
-                "Failed to remove modlist file {}: {}",
-                file_path.display(),
-                e
-            );
-        }
+    if file_path.exists()
+        && let Err(e) = std::fs::remove_file(&file_path)
+    {
+        log::warn!(
+            "Failed to remove modlist file {}: {}",
+            file_path.display(),
+            e
+        );
     }
 
     conn.prepare("DELETE FROM mod_association WHERE modlist_id = ?1")
@@ -1155,12 +1151,11 @@ pub async fn rename_modlist(
     // Check if new filename is already taken
     if let Some(existing) = Modlist::get_by_filename(&new_filename, &conn)
         .map_err(actix_web::error::ErrorInternalServerError)?
+        && existing.id != modlist_id
     {
-        if existing.id != modlist_id {
-            return Err(actix_web::error::ErrorBadRequest(
-                "A modlist with this filename already exists",
-            ));
-        }
+        return Err(actix_web::error::ErrorBadRequest(
+            "A modlist with this filename already exists",
+        ));
     }
 
     // Check if file exists on disk with new filename

--- a/wabba-tools/src/main.rs
+++ b/wabba-tools/src/main.rs
@@ -88,11 +88,7 @@ async fn server_has_hash(
     hash: &str,
 ) -> Result<bool, reqwest::Error> {
     let url = format!("{}/check/{}", server, upload_type.as_str());
-    let response = client
-        .get(&url)
-        .header(IF_NONE_MATCH, hash)
-        .send()
-        .await?;
+    let response = client.get(&url).header(IF_NONE_MATCH, hash).send().await?;
     Ok(response.status().as_u16() == 304)
 }
 
@@ -150,13 +146,13 @@ fn compare_file_lists(
     };
 
     for file in files_in_download_dir {
-        if !required_files.contains(&file) {
+        if !required_files.contains(file) {
             result.extraneous_files.push(file.clone());
         }
     }
 
     for file in required_files {
-        if files_in_download_dir.contains(&file) {
+        if files_in_download_dir.contains(file) {
             result.satisfied_files.push(file.clone());
         } else {
             result.missing_files.push(file.clone());
@@ -259,9 +255,7 @@ async fn main() {
             let files: Vec<PathBuf> = download_directory
                 .file_paths()
                 .into_iter()
-                .filter(|p| {
-                    p.file_name().and_then(|n| n.to_str()) != Some(CACHE_FILENAME)
-                })
+                .filter(|p| p.file_name().and_then(|n| n.to_str()) != Some(CACHE_FILENAME))
                 .collect();
             log::info!(
                 "Found {} candidate files in {}",
@@ -278,7 +272,11 @@ async fn main() {
                 SyncCache::default()
             });
             if use_cache {
-                log::info!("Loaded {} cached hashes from {}", old_cache.len(), directory.display());
+                log::info!(
+                    "Loaded {} cached hashes from {}",
+                    old_cache.len(),
+                    directory.display()
+                );
             } else {
                 log::info!("Cache disabled (--no-cache); rehashing every file");
             }
@@ -312,13 +310,11 @@ async fn main() {
                             .unwrap_or_default()
                             .to_string();
                         let result = (|| -> Result<String, String> {
-                            let metadata = std::fs::metadata(&file)
-                                .map_err(|e| format!("stat: {}", e))?;
+                            let metadata =
+                                std::fs::metadata(&file).map_err(|e| format!("stat: {}", e))?;
                             let (size, mtime_nanos) = file_fingerprint(&metadata);
 
-                            if let Some(cached) =
-                                old_cache.lookup(&filename, size, mtime_nanos)
-                            {
+                            if let Some(cached) = old_cache.lookup(&filename, size, mtime_nanos) {
                                 log::debug!("Cache hit for {}", filename);
                                 new_cache.lock().unwrap().insert(
                                     filename.clone(),
@@ -329,8 +325,8 @@ async fn main() {
                                 return Ok(cached);
                             }
 
-                            let hash = Hash::compute_file(&file)
-                                .map_err(|e| format!("hash: {}", e))?;
+                            let hash =
+                                Hash::compute_file(&file).map_err(|e| format!("hash: {}", e))?;
                             new_cache.lock().unwrap().insert(
                                 filename,
                                 size,
@@ -368,21 +364,23 @@ async fn main() {
                         hashed.push((file, hash));
                     }
                     Err(e) => {
-                        log::error!("[{}/{}] Failed to hash {}: {}", completed, total, filename, e);
+                        log::error!(
+                            "[{}/{}] Failed to hash {}: {}",
+                            completed,
+                            total,
+                            filename,
+                            e
+                        );
                         failed += 1;
                     }
                 }
 
-                if use_cache && completed % CACHE_FLUSH_INTERVAL == 0 {
+                if use_cache && completed.is_multiple_of(CACHE_FLUSH_INTERVAL) {
                     let snapshot = new_cache.lock().unwrap().clone();
                     if let Err(e) = snapshot.save(directory) {
                         log::warn!("Cache flush failed at {} entries: {}", completed, e);
                     } else {
-                        log::debug!(
-                            "Flushed cache ({}/{} files hashed)",
-                            completed,
-                            total
-                        );
+                        log::debug!("Flushed cache ({}/{} files hashed)", completed, total);
                     }
                 }
             }


### PR DESCRIPTION
One-shot mechanical pass:
- `cargo fmt --all` per workspace root
- `cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged` per workspace root

Establishes a clean baseline so the on-disk code matches what Rust 1.96's rustfmt/clippy expects.

Part of kj800x/homelab#4.