### PR TITLE
Redesign table views: identity cell, source chips, copyable hashes

### DIFF
--- a/wabba-protocol/src/archive_state.rs
+++ b/wabba-protocol/src/archive_state.rs
@@ -102,6 +102,56 @@ impl ArchiveState {
         }
     }
 
+    /// Short human-readable label for the download source type. Matches the
+    /// labels rendered on the mod details page.
+    pub fn source_label(&self) -> &'static str {
+        match self {
+            ArchiveState::NexusDownloader { .. } => "Nexus Mods",
+            ArchiveState::HttpDownloader { .. } => "HTTP Download",
+            ArchiveState::WabbajackCDNDownloader { .. } => "Wabbajack CDN",
+            ArchiveState::ManualDownloader { .. } => "Manual Download",
+            ArchiveState::MegaDownloader { .. } => "MEGA",
+            ArchiveState::GoogleDriveDownloader { .. } => "Google Drive",
+            ArchiveState::MediaFireDownloader { .. } => "MediaFire",
+            ArchiveState::LoversLabOAuthDownloader { .. } => "LoversLab",
+            ArchiveState::GameFileSourceDownloader { .. } => "Game File",
+            ArchiveState::UnknownDownloader => "Unknown Source",
+        }
+    }
+
+    /// Terse label for the source chip shown in dense list/table views.
+    /// Keep these short; the full [`Self::source_label`] is used on detail pages.
+    pub fn source_chip_label(&self) -> &'static str {
+        match self {
+            ArchiveState::NexusDownloader { .. } => "Nexus",
+            ArchiveState::HttpDownloader { .. } => "HTTP",
+            ArchiveState::WabbajackCDNDownloader { .. } => "CDN",
+            ArchiveState::ManualDownloader { .. } => "Manual",
+            ArchiveState::MegaDownloader { .. } => "MEGA",
+            ArchiveState::GoogleDriveDownloader { .. } => "GDrive",
+            ArchiveState::MediaFireDownloader { .. } => "MediaFire",
+            ArchiveState::LoversLabOAuthDownloader { .. } => "LoversLab",
+            ArchiveState::GameFileSourceDownloader { .. } => "Game",
+            ArchiveState::UnknownDownloader => "Unknown",
+        }
+    }
+
+    /// CSS class suffix used to colour the source chip (e.g. `nexus` -> `.source-chip.nexus`).
+    pub fn source_chip_class(&self) -> &'static str {
+        match self {
+            ArchiveState::NexusDownloader { .. } => "nexus",
+            ArchiveState::HttpDownloader { .. } => "http",
+            ArchiveState::WabbajackCDNDownloader { .. } => "cdn",
+            ArchiveState::ManualDownloader { .. } => "manual",
+            ArchiveState::MegaDownloader { .. } => "mega",
+            ArchiveState::GoogleDriveDownloader { .. } => "gdrive",
+            ArchiveState::MediaFireDownloader { .. } => "mediafire",
+            ArchiveState::LoversLabOAuthDownloader { .. } => "loverslab",
+            ArchiveState::GameFileSourceDownloader { .. } => "game",
+            ArchiveState::UnknownDownloader => "unknown",
+        }
+    }
+
     pub fn name(&self) -> Option<String> {
         match self {
             ArchiveState::NexusDownloader { name, .. } => Some(name.clone()),

--- a/wabba-server/src/res/styles.css
+++ b/wabba-server/src/res/styles.css
@@ -69,7 +69,6 @@
 
   .modlist-table {
     width: 100%;
-    max-width: 100%;
     border-collapse: collapse;
     background-color: white;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -86,93 +85,10 @@
       padding: 0.75rem 1rem;
       text-align: left;
       font-weight: 600;
-      font-size: 0.85rem;
+      font-size: 0.8rem;
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      word-wrap: break-word;
-      overflow-wrap: break-word;
-
-      &:nth-child(1) {
-        width: 18%;
-      }
-
-      /* Name */
-      &:nth-child(2) {
-        width: 8%;
-      }
-
-      /* Version */
-      &:nth-child(3) {
-        width: 18%;
-      }
-
-      /* Filename */
-      &:nth-child(4) {
-        width: 8%;
-      }
-
-      /* Size */
-      &:nth-child(5) {
-        width: 15%;
-      }
-
-      /* Hash */
-      &:nth-child(6) {
-        width: 8%;
-      }
-
-      /* Mods total */
-      &:nth-child(7) {
-        width: 8%;
-      }
-
-      /* Mods available */
-      &:nth-child(8) {
-        width: 17%;
-      }
-
-      /* Status */
-    }
-
-    /* Mods table variant - 7 columns: Filename, Name, Version, Size, Hash, Modlists, Status */
-    &.mods-table {
-      th {
-        &:nth-child(1) {
-          width: 20%;
-        }
-
-        /* Filename */
-        &:nth-child(2) {
-          width: 25%;
-        }
-
-        /* Name */
-        &:nth-child(3) {
-          width: 10%;
-        }
-
-        /* Version */
-        &:nth-child(4) {
-          width: 10%;
-        }
-
-        /* Size */
-        &:nth-child(5) {
-          width: 18%;
-        }
-
-        /* Hash */
-        &:nth-child(6) {
-          width: 7%;
-        }
-
-        /* Modlists */
-        &:nth-child(7) {
-          width: 10%;
-        }
-
-        /* Status */
-      }
+      white-space: nowrap;
     }
 
     tbody tr {
@@ -216,39 +132,16 @@
     }
 
     td {
-      padding: 0.75rem 1rem;
+      padding: 0.6rem 1rem;
       vertical-align: middle;
-      word-wrap: break-word;
-      overflow-wrap: break-word;
-      word-break: break-word;
-      overflow: hidden;
       font-size: 0.9rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
-      &.name a {
-        color: #3498db;
-        text-decoration: none;
-        font-weight: 500;
-        transition: color 0.2s;
-
-        &:hover {
-          color: #2980b9;
-          text-decoration: underline;
-        }
-      }
-
-      &.filename {
-        font-family: 'Courier New', monospace;
-        font-size: 0.9rem;
-        color: #666;
-      }
-
-      &.hash code {
-        font-family: 'Courier New', monospace;
-        font-size: 0.85rem;
-        color: #666;
-        background-color: #f5f5f5;
-        padding: 0.2rem 0.4rem;
-        border-radius: 3px;
+      &.version {
+        white-space: normal;
+        word-break: break-word;
       }
 
       &.status {
@@ -259,12 +152,12 @@
 
   .status-badge {
     display: inline-block;
-    padding: 0.4rem 0.8rem;
+    padding: 0.3rem 0.6rem;
     border-radius: 4px;
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: 0.75rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.3px;
 
     &.available {
       background-color: #d4edda;
@@ -623,7 +516,6 @@
 
   .mod-table {
     width: 100%;
-    max-width: 100%;
     border-collapse: collapse;
     background-color: white;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -637,105 +529,13 @@
     }
 
     th {
-      padding: 1rem;
+      padding: 0.85rem 1rem;
       text-align: left;
       font-weight: 600;
-      font-size: 0.9rem;
+      font-size: 0.8rem;
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      word-wrap: break-word;
-      overflow-wrap: break-word;
-
-      &:nth-child(1) {
-        width: 18%;
-      }
-
-      /* Filename */
-      &:nth-child(2) {
-        width: 23%;
-      }
-
-      /* Name */
-      &:nth-child(3) {
-        width: 10%;
-      }
-
-      /* Version */
-      &:nth-child(4) {
-        width: 10%;
-      }
-
-      /* Size */
-      &:nth-child(5) {
-        width: 23%;
-      }
-
-      /* Hash */
-      &:nth-child(6) {
-        width: 16%;
-      }
-
-      /* Status */
-    }
-
-    &.mod-table-with-id {
-      th {
-        &:nth-child(1) {
-          width: 8%;
-        }
-
-        /* ID */
-        &:nth-child(2) {
-          width: 16%;
-        }
-
-        /* Filename */
-        &:nth-child(3) {
-          width: 20%;
-        }
-
-        /* Name */
-        &:nth-child(4) {
-          width: 9%;
-        }
-
-        /* Version */
-        &:nth-child(5) {
-          width: 9%;
-        }
-
-        /* Size */
-        &:nth-child(6) {
-          width: 22%;
-        }
-
-        /* Hash */
-        &:nth-child(7) {
-          width: 16%;
-        }
-
-        /* Status */
-      }
-
-      td {
-        &.id {
-          font-family: 'Courier New', monospace;
-          font-size: 0.85rem;
-          color: #666;
-        }
-
-        &.name a {
-          color: #3498db;
-          text-decoration: none;
-          font-weight: 500;
-          transition: color 0.2s;
-
-          &:hover {
-            color: #2980b9;
-            text-decoration: underline;
-          }
-        }
-      }
+      white-space: nowrap;
     }
 
     tbody tr {
@@ -779,32 +579,27 @@
     }
 
     td {
-      padding: 1rem;
+      padding: 0.6rem 1rem;
       vertical-align: middle;
-      word-wrap: break-word;
-      overflow-wrap: break-word;
-      word-break: break-word;
+      font-size: 0.9rem;
+      white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
 
-      &.filename {
-        font-family: 'Courier New', monospace;
-        font-size: 0.9rem;
-        color: #666;
-      }
-
-      &.name em,
-      &.version em {
-        color: #999;
-        font-style: italic;
-      }
-
-      &.hash code {
+      &.id {
         font-family: 'Courier New', monospace;
         font-size: 0.85rem;
         color: #666;
-        background-color: #f5f5f5;
-        padding: 0.2rem 0.4rem;
-        border-radius: 3px;
+      }
+
+      &.version {
+        white-space: normal;
+        word-break: break-word;
+
+        em {
+          color: #999;
+          font-style: italic;
+        }
       }
 
       &.status {
@@ -815,12 +610,12 @@
 
   .status-badge {
     display: inline-block;
-    padding: 0.4rem 0.8rem;
+    padding: 0.3rem 0.6rem;
     border-radius: 4px;
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: 0.75rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.3px;
 
     &.available {
       background-color: #d4edda;
@@ -837,4 +632,124 @@
       color: #721c24;
     }
   }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Shared table components (identity cell, source chips, copyable hash).
+   Placed at the top level so they apply on both listing and details pages,
+   and after the table rules so `td.identity` wins the cascade.
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* Column widths for `table-layout: fixed`. The width-less `.col-mod` column
+   soaks up whatever is left, so the identity column is always the widest. */
+.col-mod { /* no width: absorbs remaining space */ }
+.col-id { width: 5.5rem; }
+.col-version { width: 7rem; }
+.col-size { width: 6.5rem; }
+.col-hash { width: 9.5rem; }
+.col-count { width: 7.5rem; }
+.col-status { width: 9.5rem; }
+
+/* Identity cell: bold name + chip on top, muted filename underneath.
+   Selector is body-class-qualified to outrank the nested `.page-* table td`
+   `white-space: nowrap` rule so long names wrap instead of clipping. */
+.page-listing .modlist-table td.identity,
+.page-details .mod-table td.identity {
+  white-space: normal;
+  vertical-align: middle;
+}
+
+.identity-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Inline flow so long names wrap naturally and the chip trails the last word. */
+.identity-primary {
+  line-height: 1.4;
+}
+
+.identity-name {
+  color: #2c3e50;
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.identity-link:hover .identity-name {
+  color: #2980b9;
+  text-decoration: underline;
+}
+
+.identity-sub {
+  display: block;
+  margin-top: 0.15rem;
+  font-family: 'Courier New', monospace;
+  font-size: 0.78rem;
+  color: #6b7280;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Source chips. Categorical palette — green/amber/red are reserved for status. */
+.source-chip {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  vertical-align: 1px;
+  background-color: #f1f5f9;
+  color: #475569;
+}
+
+.source-chip.nexus     { background-color: #e0e7ff; color: #3730a3; }
+.source-chip.manual    { background-color: #e2e8f0; color: #334155; }
+.source-chip.http      { background-color: #ccfbf1; color: #115e59; }
+.source-chip.cdn       { background-color: #ede9fe; color: #5b21b6; }
+.source-chip.gdrive    { background-color: #cffafe; color: #155e75; }
+.source-chip.game      { background-color: #f3e3d0; color: #7c4a1e; }
+.source-chip.mega      { background-color: #ffedd5; color: #9a3412; }
+.source-chip.mediafire { background-color: #fce7f3; color: #9d174d; }
+.source-chip.loverslab { background-color: #f5e1ff; color: #7e22ce; }
+.source-chip.unknown   { background-color: #f1f5f9; color: #64748b; }
+
+/* Copyable hash cell — click to copy the full hash (e.g. for `prune --keep`). */
+.hash-copy {
+  border: none;
+  background: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.hash-copy code {
+  font-family: 'Courier New', monospace;
+  font-size: 0.85rem;
+  color: #555;
+  background-color: #f5f5f5;
+  padding: 0.2rem 0.45rem;
+  border-radius: 3px;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.hash-copy:hover code {
+  background-color: #e5edff;
+  color: #1d4ed8;
+}
+
+.hash-copy.copied code,
+.hash-copy.copied:hover code {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.hash-copy.copied code::after {
+  content: " ✓";
 }

--- a/wabba-server/src/web/components.rs
+++ b/wabba-server/src/web/components.rs
@@ -1,0 +1,142 @@
+//! Shared maud components for the table-based list views.
+//!
+//! These centralise the "identity cell" (bold name + source chip + muted
+//! filename subline), the copyable hash cell, and the small clipboard handler
+//! so every table renders them identically.
+
+use maud::{Markup, PreEscaped, html};
+
+use crate::db::mod_association::ModAssociation;
+
+/// Middle-truncate a string to roughly `max` characters, keeping the head and
+/// tail (which carry the most signal in mod filenames). Operates on `char`
+/// boundaries so it is safe for non-ASCII input.
+pub fn middle_truncate(s: &str, max: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max {
+        return s.to_string();
+    }
+    // Reserve one char for the ellipsis; weight the head a little heavier.
+    let budget = max.saturating_sub(1);
+    let head = (budget * 2) / 3;
+    let tail = budget - head;
+    let head_s: String = chars[..head].iter().collect();
+    let tail_s: String = chars[chars.len() - tail..].iter().collect();
+    format!("{head_s}…{tail_s}")
+}
+
+/// Emit a `<colgroup>` assigning each column a width class. Used with
+/// `table-layout: fixed` so the identity column (`col-mod`, left width-less)
+/// absorbs the remaining space while the data columns stay compact — and no
+/// row's content can ever blow the table past its container.
+pub fn colgroup(cols: &[&str]) -> Markup {
+    html! {
+        colgroup {
+            @for c in cols {
+                col class=(c);
+            }
+        }
+    }
+}
+
+/// The shared identity cell. `primary` is the bold first line; `secondary` (when
+/// present) renders as a muted, middle-truncated monospace subline with the full
+/// value in a `title` tooltip; `chip` is an optional `(label, css_class)` pill.
+pub fn identity_cell(
+    href: &str,
+    primary: &str,
+    secondary: Option<&str>,
+    chip: Option<(&str, &str)>,
+) -> Markup {
+    html! {
+        td.identity {
+            a.identity-link href=(href) {
+                span.identity-primary {
+                    span.identity-name { (primary) }
+                    @if let Some((label, class)) = chip {
+                        span class=(format!("source-chip {class}")) { (label) }
+                    }
+                }
+                @if let Some(sub) = secondary {
+                    @if !sub.is_empty() {
+                        span.identity-sub title=(sub) { (middle_truncate(sub, 52)) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Identity cell for a mod row. Promotes the filename to the primary line when
+/// no name is known, and tags the row with the source chip from `assoc`.
+pub fn mod_identity_cell(
+    href: &str,
+    disk_filename: Option<&str>,
+    assoc: Option<&ModAssociation>,
+) -> Markup {
+    let name = assoc
+        .and_then(|a| a.name.as_deref())
+        .filter(|s| !s.is_empty());
+    let filename = disk_filename
+        .or_else(|| assoc.map(|a| a.filename.as_str()))
+        .filter(|s| !s.is_empty());
+
+    let primary = name.or(filename).unwrap_or("Unknown");
+    // Only show the filename subline when it is not already the primary line.
+    let secondary = if name.is_some() { filename } else { None };
+    let chip = assoc.map(|a| (a.source.source_chip_label(), a.source.source_chip_class()));
+
+    identity_cell(href, primary, secondary, chip)
+}
+
+/// Identity cell for a modlist row: name on top, its own filename underneath.
+/// Modlists have no download source, so there is no chip.
+pub fn modlist_identity_cell(href: &str, name: &str, filename: &str) -> Markup {
+    let secondary = Some(filename).filter(|s| !s.is_empty());
+    identity_cell(href, name, secondary, None)
+}
+
+/// A hash cell rendering the full (short) hash on one line as a click-to-copy
+/// button — handy for pasting into CLI flags like `prune --keep <hash>`.
+pub fn hash_cell(hash: &str) -> Markup {
+    html! {
+        td.hash {
+            button.hash-copy type="button" data-hash=(hash) title="Click to copy full hash" {
+                code { (hash) }
+            }
+        }
+    }
+}
+
+/// Tiny delegated click handler that copies `data-hash` to the clipboard and
+/// flashes the button. Include once per page that renders [`hash_cell`].
+pub fn clipboard_script() -> Markup {
+    html! {
+        script {
+            (PreEscaped(r#"
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('.hash-copy');
+  if (!btn) return;
+  e.preventDefault();
+  var text = btn.dataset.hash;
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text);
+    } else {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      ta.remove();
+    }
+  } catch (_) {}
+  btn.classList.add('copied');
+  setTimeout(function () { btn.classList.remove('copied'); }, 1200);
+});
+"#))
+        }
+    }
+}

--- a/wabba-server/src/web/details_page.rs
+++ b/wabba-server/src/web/details_page.rs
@@ -9,6 +9,9 @@ use crate::data_dir::DataDir;
 use crate::db::mod_association::ModAssociation;
 use crate::db::mod_data::Mod;
 use crate::db::modlist::Modlist;
+use crate::web::components::{
+    clipboard_script, colgroup, hash_cell, mod_identity_cell, modlist_identity_cell,
+};
 use wabba_protocol::archive_state::ArchiveState;
 
 fn format_size(bytes: u64) -> String {
@@ -446,6 +449,7 @@ pub async fn mod_details_page(
                     " - Mod Details"
                 }
                 link rel="stylesheet" href="/res/styles.css";
+                (clipboard_script())
             }
             body.page-details {
                 div.container {
@@ -568,11 +572,11 @@ pub async fn mod_details_page(
                         p.empty-state { "No conflicts found." }
                     } @else {
                         table.mod-table.mod-table-with-id {
+                            (colgroup(&["col-id", "col-mod", "col-version", "col-size", "col-hash", "col-status"]))
                             thead {
                                 tr {
                                     th { "ID" }
-                                    th { "Filename" }
-                                    th { "Name" }
+                                    th { "Mod" }
                                     th { "Version" }
                                     th { "Size" }
                                     th { "Hash" }
@@ -583,44 +587,11 @@ pub async fn mod_details_page(
                                 @for (related_mod, related_first_assoc) in &mods_same_filename_with_assocs {
                                     tr class=(if related_mod.is_available() { "" } else { "unavailable-row" }) {
                                         td.id { (related_mod.id) }
-                                        td.filename {
-                                            a href=(format!("/mod/{}", related_mod.id)) {
-                                                @match &related_mod.disk_filename {
-                                                    Some(disk_filename) => {
-                                                        (disk_filename.clone())
-                                                    }
-                                                    None => {
-                                                        @match related_first_assoc {
-                                                            Some(assoc) => {
-                                                                (assoc.filename.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        td.name {
-                                            a href=(format!("/mod/{}", related_mod.id)) {
-                                                @match related_first_assoc {
-                                                    Some(assoc) => {
-                                                        @match &assoc.name {
-                                                            Some(name) => {
-                                                                (name.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                    None => {
-                                                        em { "Unknown" }
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        (mod_identity_cell(
+                                            &format!("/mod/{}", related_mod.id),
+                                            related_mod.disk_filename.as_deref(),
+                                            related_first_assoc.as_ref(),
+                                        ))
                                         td.version {
                                             @match related_first_assoc {
                                                 Some(assoc) => {
@@ -641,9 +612,7 @@ pub async fn mod_details_page(
                                         td.size {
                                             (format_size(related_mod.size))
                                         }
-                                        td.hash {
-                                            code { (format_hash(&related_mod.xxhash64)) }
-                                        }
+                                        (hash_cell(&related_mod.xxhash64))
                                         td.status {
                                             @if related_mod.is_available() {
                                                 span.status-badge.available { "Available" }
@@ -664,48 +633,27 @@ pub async fn mod_details_page(
                         p.empty-state { "This mod is not associated with any modlists." }
                     } @else {
                         table.mod-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Name" }
+                                    th { "Modlist" }
                                     th { "Version" }
-                                    th { "Filename" }
                                     th { "Size" }
                                     th { "Hash" }
                                     th { "Status" }
                                 }
                             }
                             tbody {
-                                @for (modlist, assoc, has_lost_forever) in &modlists_with_assocs {
+                                @for (modlist, _assoc, has_lost_forever) in &modlists_with_assocs {
                                     tr {
-                                        td.name {
-                                            a href=(format!("/modlists/{}", modlist.id)) {
-                                                (modlist.name.clone())
-                                            }
-                                        }
+                                        (modlist_identity_cell(
+                                            &format!("/modlists/{}", modlist.id),
+                                            &modlist.name,
+                                            &modlist.filename,
+                                        ))
                                         td.version { (modlist.version.clone()) }
-                                        td.filename {
-                                            @match assoc {
-                                                Some(assoc) => {
-                                                    (assoc.filename.clone())
-                                                }
-                                                None => {
-                                                    @match &mod_item.disk_filename {
-                                                        Some(disk_filename) => {
-                                                            (disk_filename.clone())
-                                                        }
-                                                        None => {
-                                                            em { "Unknown" }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        td.size { (format_size(mod_item.size)) }
-                                        td.hash {
-                                            span.hash {
-                                                code { (format_hash(&mod_item.xxhash64)) }
-                                            }
-                                        }
+                                        td.size { (format_size(modlist.size)) }
+                                        (hash_cell(&modlist.xxhash64))
                                         td.status {
                                             @if *has_lost_forever {
                                                 span.status-badge.missing { "Uninstallable" }
@@ -727,11 +675,11 @@ pub async fn mod_details_page(
                             p.empty-state { "No other versions found." }
                         } @else {
                             table.mod-table.mod-table-with-id {
+                                (colgroup(&["col-id", "col-mod", "col-version", "col-size", "col-hash", "col-status"]))
                                 thead {
                                     tr {
                                         th { "ID" }
-                                        th { "Filename" }
-                                        th { "Name" }
+                                        th { "Mod" }
                                         th { "Version" }
                                         th { "Size" }
                                         th { "Hash" }
@@ -742,44 +690,11 @@ pub async fn mod_details_page(
                                 @for (related_mod, related_first_assoc) in &mods_same_name {
                                         tr class=(if related_mod.is_available() { "" } else { "unavailable-row" }) {
                                             td.id { (related_mod.id) }
-                                            td.filename {
-                                                a href=(format!("/mod/{}", related_mod.id)) {
-                                                    @match &related_mod.disk_filename {
-                                                        Some(disk_filename) => {
-                                                            (disk_filename.clone())
-                                                        }
-                                                        None => {
-                                                            @match related_first_assoc {
-                                                                Some(assoc) => {
-                                                                    (assoc.filename.clone())
-                                                                }
-                                                                None => {
-                                                                    em { "Unknown" }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            td.name {
-                                                a href=(format!("/mod/{}", related_mod.id)) {
-                                                    @match related_first_assoc {
-                                                        Some(assoc) => {
-                                                            @match &assoc.name {
-                                                                Some(name) => {
-                                                                    (name.clone())
-                                                                }
-                                                                None => {
-                                                                    em { "Unknown" }
-                                                                }
-                                                            }
-                                                        }
-                                                        None => {
-                                                            em { "Unknown" }
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                            (mod_identity_cell(
+                                                &format!("/mod/{}", related_mod.id),
+                                                related_mod.disk_filename.as_deref(),
+                                                related_first_assoc.as_ref(),
+                                            ))
                                             td.version {
                                                 @match related_first_assoc {
                                                     Some(assoc) => {
@@ -800,9 +715,7 @@ pub async fn mod_details_page(
                                             td.size {
                                                 (format_size(related_mod.size))
                                             }
-                                            td.hash {
-                                                code { (format_hash(&related_mod.xxhash64)) }
-                                            }
+                                            (hash_cell(&related_mod.xxhash64))
                                             td.status {
                                                 @if related_mod.is_available() {
                                                     span.status-badge.available { "Available" }
@@ -1258,6 +1171,7 @@ pub async fn details_page(
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (modlist.name.clone()) " - Modlist Details" }
                 link rel="stylesheet" href="/res/styles.css";
+                (clipboard_script())
             }
             body.page-details {
                 div.container {
@@ -1325,10 +1239,10 @@ pub async fn details_page(
                     @if show_missing_table {
                         h2 { "Missing Mods" }
                         table.mod-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Filename" }
-                                    th { "Name" }
+                                    th { "Mod" }
                                     th { "Version" }
                                     th { "Size" }
                                     th { "Hash" }
@@ -1338,44 +1252,11 @@ pub async fn details_page(
                             tbody {
                                 @for (mod_item, assoc) in &unavailable_mods_with_assocs {
                                     tr {
-                                        td.filename {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match assoc {
-                                                    Some(assoc) => {
-                                                        (assoc.filename.clone())
-                                                    }
-                                                    None => {
-                                                        @match &mod_item.disk_filename {
-                                                            Some(disk_filename) => {
-                                                                (disk_filename.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        td.name {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match assoc {
-                                                    Some(assoc) => {
-                                                        @match &assoc.name {
-                                                            Some(name) => {
-                                                                (name.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                    None => {
-                                                        em { "Unknown" }
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        (mod_identity_cell(
+                                            &format!("/mod/{}", mod_item.id),
+                                            mod_item.disk_filename.as_deref(),
+                                            *assoc,
+                                        ))
                                         td.version {
                                             @match assoc {
                                                 Some(assoc) => {
@@ -1396,9 +1277,7 @@ pub async fn details_page(
                                         td.size {
                                             (format_size(mod_item.size))
                                         }
-                                        td.hash {
-                                            code { (format_hash(&mod_item.xxhash64)) }
-                                        }
+                                        (hash_cell(&mod_item.xxhash64))
                                         td.status {
                                             @if mod_item.lost_forever {
                                                 span.status-badge.missing { "Lost Forever" }
@@ -1417,10 +1296,10 @@ pub async fn details_page(
                         p.empty-state { "No mods found." }
                     } @else {
                         table.mod-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Filename" }
-                                    th { "Name" }
+                                    th { "Mod" }
                                     th { "Version" }
                                     th { "Size" }
                                     th { "Hash" }
@@ -1430,44 +1309,11 @@ pub async fn details_page(
                             tbody {
                                 @for (mod_item, assoc) in &mods_with_assocs {
                                     tr {
-                                        td.filename {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match assoc {
-                                                    Some(assoc) => {
-                                                        (assoc.filename.clone())
-                                                    }
-                                                    None => {
-                                                        @match &mod_item.disk_filename {
-                                                            Some(disk_filename) => {
-                                                                (disk_filename.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        td.name {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match assoc {
-                                                    Some(assoc) => {
-                                                        @match &assoc.name {
-                                                            Some(name) => {
-                                                                (name.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                    None => {
-                                                        em { "Unknown" }
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        (mod_identity_cell(
+                                            &format!("/mod/{}", mod_item.id),
+                                            mod_item.disk_filename.as_deref(),
+                                            *assoc,
+                                        ))
                                         td.version {
                                             @match assoc {
                                                 Some(assoc) => {
@@ -1488,9 +1334,7 @@ pub async fn details_page(
                                         td.size {
                                             (format_size(mod_item.size))
                                         }
-                                        td.hash {
-                                            code { (format_hash(&mod_item.xxhash64)) }
-                                        }
+                                        (hash_cell(&mod_item.xxhash64))
                                         td.status {
                                             @if mod_item.is_available() {
                                                 span.status-badge.available { "Available" }

--- a/wabba-server/src/web/listing_page.rs
+++ b/wabba-server/src/web/listing_page.rs
@@ -5,6 +5,9 @@ use r2d2_sqlite::SqliteConnectionManager;
 
 use crate::db::mod_data::Mod;
 use crate::db::modlist::Modlist;
+use crate::web::components::{
+    clipboard_script, colgroup, hash_cell, mod_identity_cell, modlist_identity_cell,
+};
 
 fn format_size(bytes: u64) -> String {
     const KB: u64 = 1024;
@@ -19,14 +22,6 @@ fn format_size(bytes: u64) -> String {
         format!("{:.2} KB", bytes as f64 / KB as f64)
     } else {
         format!("{} B", bytes)
-    }
-}
-
-fn format_hash(hash: &str) -> String {
-    if hash.len() > 16 {
-        format!("{}...", &hash[..16])
-    } else {
-        hash.to_string()
     }
 }
 
@@ -62,6 +57,7 @@ pub async fn listing_page(
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { "Modlists" }
                 link rel="stylesheet" href="/res/styles.css";
+                (clipboard_script())
             }
             body.page-listing {
                 div.container {
@@ -77,15 +73,14 @@ pub async fn listing_page(
                         p.empty-state { "No modlists found." }
                     } @else {
                         table.modlist-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-count", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Name" }
+                                    th { "Modlist" }
                                     th { "Version" }
-                                    th { "Filename" }
                                     th { "Size" }
                                     th { "Hash" }
-                                    th { "Mods total" }
-                                    th { "Mods available" }
+                                    th { "Mods" }
                                     th { "Status" }
                                 }
                             }
@@ -100,19 +95,17 @@ pub async fn listing_page(
                                             ""
                                         }
                                     ) {
-                                        td.name {
-                                            a href={"/modlists/" (modlist.id)} {
-                                                (modlist.name)
-                                            }
-                                        }
+                                        (modlist_identity_cell(
+                                            &format!("/modlists/{}", modlist.id),
+                                            &modlist.name,
+                                            &modlist.filename,
+                                        ))
                                         td.version { (modlist.version) }
-                                        td.filename { (modlist.filename) }
                                         td.size { (format_size(modlist.size)) }
-                                        td.hash {
-                                            code { (format_hash(&modlist.xxhash64)) }
+                                        (hash_cell(&modlist.xxhash64))
+                                        td.count {
+                                            (mods_available) " / " (mods_total)
                                         }
-                                        td { (mods_total) }
-                                        td { (mods_available) }
                                         td.status {
                                             @if *has_lost_forever {
                                                 span.status-badge.missing { "Uninstallable" }
@@ -186,6 +179,7 @@ pub async fn muted_modlists_page(
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { "Muted Modlists" }
                 link rel="stylesheet" href="/res/styles.css";
+                (clipboard_script())
             }
             body.page-listing {
                 div.container {
@@ -200,15 +194,14 @@ pub async fn muted_modlists_page(
                         p.empty-state { "No muted modlists found." }
                     } @else {
                         table.modlist-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-count", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Name" }
+                                    th { "Modlist" }
                                     th { "Version" }
-                                    th { "Filename" }
                                     th { "Size" }
                                     th { "Hash" }
-                                    th { "Mods total" }
-                                    th { "Mods available" }
+                                    th { "Mods" }
                                     th { "Status" }
                                 }
                             }
@@ -223,19 +216,17 @@ pub async fn muted_modlists_page(
                                             "muted-row"
                                         }
                                     ) {
-                                        td.name {
-                                            a href={"/modlists/" (modlist.id)} {
-                                                (modlist.name)
-                                            }
-                                        }
+                                        (modlist_identity_cell(
+                                            &format!("/modlists/{}", modlist.id),
+                                            &modlist.name,
+                                            &modlist.filename,
+                                        ))
                                         td.version { (modlist.version) }
-                                        td.filename { (modlist.filename) }
                                         td.size { (format_size(modlist.size)) }
-                                        td.hash {
-                                            code { (format_hash(&modlist.xxhash64)) }
+                                        (hash_cell(&modlist.xxhash64))
+                                        td.count {
+                                            (mods_available) " / " (mods_total)
                                         }
-                                        td { (mods_total) }
-                                        td { (mods_available) }
                                         td.status {
                                             @if *has_lost_forever {
                                                 span.status-badge.missing { "Uninstallable" }
@@ -291,6 +282,7 @@ pub async fn mods_listing_page(
                     }
                 }
                 link rel="stylesheet" href="/res/styles.css";
+                (clipboard_script())
             }
             body.page-listing {
                 div.container {
@@ -322,10 +314,10 @@ pub async fn mods_listing_page(
                         }
                     } @else {
                         table.modlist-table.mods-table {
+                            (colgroup(&["col-mod", "col-version", "col-size", "col-hash", "col-count", "col-status"]))
                             thead {
                                 tr {
-                                    th { "Filename" }
-                                    th { "Name" }
+                                    th { "Mod" }
                                     th { "Version" }
                                     th { "Size" }
                                     th { "Hash" }
@@ -336,44 +328,11 @@ pub async fn mods_listing_page(
                             tbody {
                                 @for (mod_item, modlists_count, first_assoc) in &mods_with_metadata {
                                     tr {
-                                        td.filename {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match &mod_item.disk_filename {
-                                                    Some(disk_filename) => {
-                                                        (disk_filename)
-                                                    }
-                                                    None => {
-                                                        @match first_assoc {
-                                                            Some(assoc) => {
-                                                                (assoc.filename.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        td.name {
-                                            a href=(format!("/mod/{}", mod_item.id)) {
-                                                @match first_assoc {
-                                                    Some(assoc) => {
-                                                        @match &assoc.name {
-                                                            Some(name) => {
-                                                                (name.clone())
-                                                            }
-                                                            None => {
-                                                                em { "Unknown" }
-                                                            }
-                                                        }
-                                                    }
-                                                    None => {
-                                                        em { "Unknown" }
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        (mod_identity_cell(
+                                            &format!("/mod/{}", mod_item.id),
+                                            mod_item.disk_filename.as_deref(),
+                                            first_assoc.as_ref(),
+                                        ))
                                         td.version {
                                             @match first_assoc {
                                                 Some(assoc) => {
@@ -392,9 +351,7 @@ pub async fn mods_listing_page(
                                             }
                                         }
                                         td.size { (format_size(mod_item.size)) }
-                                        td.hash {
-                                            code { (format_hash(&mod_item.xxhash64)) }
-                                        }
+                                        (hash_cell(&mod_item.xxhash64))
                                         td { (modlists_count) }
                                         td.status {
                                             @if mod_item.is_available() {

--- a/wabba-server/src/web/mod.rs
+++ b/wabba-server/src/web/mod.rs
@@ -1,3 +1,4 @@
+pub mod components;
 pub mod details_page;
 pub mod listing_page;
 pub mod upload_page;


### PR DESCRIPTION
## Summary

Reworks every table-based view to present mods/modlists more compactly and scannably, and adds a **Source** indicator throughout.

- **Identity cell** — `Filename` + `Name` + `Source` collapse into one column: bold name, tinted source chip, muted middle-truncated filename subline (full name in a `title` tooltip). Filename is promoted to the primary line when a mod has no name. Applied to `/mods`, `/`, `/muted`, modlist-details (Required + Missing), and mod-details (Conflicts, Associated Modlists, Other Versions).
- **Source chips** — short labels (`Nexus`, `Manual`, `HTTP`, `CDN`, `GDrive`, `Game`, `MEGA`, `MediaFire`, `LoversLab`, `Unknown`) via new `ArchiveState::source_chip_label()/source_chip_class()`, with a categorical tinted-pill palette that deliberately avoids green/amber/red (reserved for status). The mod-details header keeps the full label.
- **Copyable hashes** — full hash on one line, click-to-copy with a ✓ flash. Handy for pasting into CLI flags (e.g. a future `prune --keep <hash>`).
- **Robust layout** — replaced the brittle `table-layout: fixed` + `nth-child` width maps with per-table `<colgroup>`s, so the identity column flexes and content can't overflow the container. New `web::components` module centralises the identity/hash/colgroup/clipboard helpers (cuts a lot of template duplication).
- **Cleanups** — merged the two modlist count columns into one `available / total` cell; slimmed the oversized status badges.

### Regressions fixed
Restores the **Status column** on the modlist-details page and un-clips the **source chip** on `/mods` (both were collateral from an earlier interim change; the column-system rewrite resolves them).

## Testing
- `cargo build` (workspace) + `cargo clippy` clean, no warnings.
- Manually validated every route in-browser against a copy of the production DB (~17 modlists, ~5,729 mods): `/`, `/mods`, `/mods?filter=unavailable`, `/modlists/muted`, `/modlists/{id}` (Required + Missing tables), `/mod/{id}` (Source + Conflicts + Associated + Other Versions), `/upload`. No horizontal overflow, no console errors, hash copy verified.

## Follow-ups (not in this PR)
Largest remaining usability gap is search/sort/filter/pagination on the 5,729-row `/mods` table; plus a global nav/breadcrumb pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)