### PR TITLE
Add fetch-mods command to download a modlist's required mods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,6 +3029,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger 0.11.8",
+ "futures-util",
  "log",
  "reqwest",
  "serde",

--- a/wabba-server/src/db/mod_data.rs
+++ b/wabba-server/src/db/mod_data.rs
@@ -147,6 +147,32 @@ impl Mod {
         Ok(mods)
     }
 
+    /// Returns every mod required by a modlist paired with the filename that
+    /// modlist expects it under (from `mod_association`). A single mod can be
+    /// shared across modlists under different names, so the per-modlist
+    /// association filename — not `disk_filename` — is the correct local
+    /// download name. Used by the `/modlist/mods` endpoint that drives the
+    /// `fetch-mods` CLI command.
+    pub fn get_with_filenames_by_modlist_id(
+        modlist_id: u64,
+        conn: &PooledConnection<SqliteConnectionManager>,
+    ) -> Result<Vec<(Self, String)>, rusqlite::Error> {
+        let mut stmt = conn.prepare(
+            "SELECT \"mod\".id, \"mod\".disk_filename, \"mod\".size, \"mod\".xxhash64, \"mod\".lost_forever, mod_association.filename
+             FROM \"mod\"
+             INNER JOIN mod_association ON \"mod\".id = mod_association.mod_id
+             WHERE mod_association.modlist_id = ?1
+             ORDER BY mod_association.filename",
+        )?;
+        let rows = stmt
+            .query_map(params![modlist_id], |row| {
+                Ok((Mod::from_row(row)?, row.get::<_, String>(5)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
     pub fn get_by_modlist_id(
         modlist_id: u64,
         conn: &PooledConnection<SqliteConnectionManager>,

--- a/wabba-server/src/main.rs
+++ b/wabba-server/src/main.rs
@@ -34,7 +34,7 @@ use crate::db::migrations::migrate;
 use crate::prelude::*;
 use crate::resources::bootstrap::{bootstrap, bootstrap_modlists, bootstrap_mods};
 use crate::resources::{
-    check_mod, check_modlist, hello_world, resolve_hash, upload_mod, upload_modlist,
+    check_mod, check_modlist, hello_world, modlist_mods, resolve_hash, upload_mod, upload_modlist,
 };
 use crate::web::details_page::{
     delete_mod, delete_modlist, details_page, download_mod, download_modlist, mod_details_page,
@@ -66,6 +66,7 @@ async fn start_http(
             .service(check_modlist)
             .service(check_mod)
             .service(resolve_hash)
+            .service(modlist_mods)
             .service(listing_page)
             .service(mods_listing_page)
             .service(muted_modlists_page)

--- a/wabba-server/src/resources/mod.rs
+++ b/wabba-server/src/resources/mod.rs
@@ -228,6 +228,76 @@ pub async fn resolve_hash(
     Ok(HttpResponse::NotFound().finish())
 }
 
+/// One mod required by a modlist, as reported to the `fetch-mods` CLI command.
+/// `filename` is the modlist-specific download name; `available` is true when
+/// the server has the file archived on disk and can serve it.
+#[derive(serde::Serialize)]
+struct RequiredMod {
+    id: u64,
+    xxhash64: String,
+    filename: String,
+    size: u64,
+    available: bool,
+}
+
+#[derive(serde::Serialize)]
+struct ModlistManifest {
+    modlist_filename: String,
+    mods: Vec<RequiredMod>,
+}
+
+/// Lists every mod required by the modlist identified by the `If-None-Match`
+/// hash, with the filename and availability the `fetch-mods` command needs to
+/// download what is missing. 404 when the hash is not a known modlist.
+#[get("/modlist/mods")]
+pub async fn modlist_mods(
+    req: HttpRequest,
+    pool: web::Data<Pool<SqliteConnectionManager>>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let hash = req
+        .headers()
+        .get("If-None-Match")
+        .and_then(|x| x.to_str().ok());
+    let hash = match hash {
+        Some(h) => h.to_string(),
+        None => {
+            return Err(actix_web::error::ErrorBadRequest(
+                "If-None-Match header is required",
+            ));
+        }
+    };
+
+    let conn = pool
+        .get()
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let db_err = |e: rusqlite::Error| {
+        actix_web::error::ErrorInternalServerError(format!("Database error: {}", e))
+    };
+
+    let modlist = match Modlist::get_by_hash(&hash, &conn).map_err(db_err)? {
+        Some(modlist) => modlist,
+        None => return Ok(HttpResponse::NotFound().finish()),
+    };
+
+    let mods = Mod::get_with_filenames_by_modlist_id(modlist.id, &conn)
+        .map_err(db_err)?
+        .into_iter()
+        .map(|(m, filename)| RequiredMod {
+            id: m.id,
+            available: m.is_available(),
+            xxhash64: m.xxhash64,
+            size: m.size,
+            filename,
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(ModlistManifest {
+        modlist_filename: modlist.filename,
+        mods,
+    }))
+}
+
 #[get("/check/modlist")]
 pub async fn check_modlist(
     req: HttpRequest,

--- a/wabba-tools/Cargo.toml
+++ b/wabba-tools/Cargo.toml
@@ -11,5 +11,6 @@ clap = { version = "4.5.53", features = ["derive"] }
 log = "0.4.28"
 env_logger = "0.11.8"
 reqwest = { version = "0.12.14", features = ["stream", "json"] }
+futures-util = { version = "0.3.17", default-features = false, features = ["std"] }
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7.17", features = ["codec"] }

--- a/wabba-tools/src/cli.rs
+++ b/wabba-tools/src/cli.rs
@@ -107,4 +107,31 @@ pub enum Commands {
         #[arg(long = "parallel", short = 'p', value_name = "N", default_value_t = 1)]
         parallel: usize,
     },
+
+    /// Fetch every mod required by a modlist from the server into a local
+    /// downloads directory. Mods already present (matching filename and
+    /// xxhash64) are skipped; only mods the server has archived can be
+    /// fetched. Each download is verified against its expected hash.
+    FetchMods {
+        /// Base URL of the server to fetch from
+        #[arg(value_name = "SERVER")]
+        server: String,
+
+        /// Path to the local downloads directory to populate
+        #[arg(value_name = "DIRECTORY")]
+        directory: PathBuf,
+
+        /// xxhash64 of the modlist whose required mods should be fetched
+        #[arg(value_name = "MODLIST_XXHASH64")]
+        modlist: String,
+
+        /// Skip the local hash cache and rehash every candidate file.
+        #[arg(long = "no-cache")]
+        no_cache: bool,
+
+        /// Number of already-present files to hash in parallel (defaults to 1,
+        /// HDD-friendly; raise for SSD/NVMe sources).
+        #[arg(long = "parallel", short = 'p', value_name = "N", default_value_t = 1)]
+        parallel: usize,
+    },
 }

--- a/wabba-tools/src/main.rs
+++ b/wabba-tools/src/main.rs
@@ -7,11 +7,13 @@ mod download_dir;
 mod hashing;
 mod sync_cache;
 use env_logger::Builder;
+use futures_util::StreamExt;
 use reqwest::Client;
 use reqwest::header::IF_NONE_MATCH;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use wabba_protocol::{hash::Hash, wabbajack::WabbajackMetadata};
 
@@ -126,6 +128,94 @@ fn meta_path_for(path: &Path) -> PathBuf {
     let mut os = path.to_path_buf().into_os_string();
     os.push(".meta");
     PathBuf::from(os)
+}
+
+/// One mod required by a modlist, as returned by `GET /modlist/mods`. The
+/// server also sends `size`, which serde ignores here.
+#[derive(serde::Deserialize)]
+struct RequiredMod {
+    id: u64,
+    xxhash64: String,
+    filename: String,
+    available: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct ModlistManifest {
+    modlist_filename: String,
+    mods: Vec<RequiredMod>,
+}
+
+/// Fetch the list of mods required by a modlist (identified by hash). Returns
+/// `None` when the server does not know the modlist (404).
+async fn fetch_modlist_manifest(
+    client: &Client,
+    server: &str,
+    modlist_hash: &str,
+) -> Result<Option<ModlistManifest>, reqwest::Error> {
+    let url = format!("{}/modlist/mods", server);
+    let response = client
+        .get(&url)
+        .header(IF_NONE_MATCH, modlist_hash)
+        .send()
+        .await?;
+    if response.status().as_u16() == 404 {
+        return Ok(None);
+    }
+    let manifest = response
+        .error_for_status()?
+        .json::<ModlistManifest>()
+        .await?;
+    Ok(Some(manifest))
+}
+
+/// Download one mod into `directory` under `required.filename`, streaming to a
+/// temporary `.part` file, verifying its hash, then atomically renaming into
+/// place. The caller only invokes this when the destination is missing, so an
+/// existing destination is never silently overwritten by this command.
+async fn download_required_mod(
+    client: &Client,
+    server: &str,
+    required: &RequiredMod,
+    directory: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let url = format!("{}/mod/{}/download", server, required.id);
+    let response = client.get(&url).send().await?.error_for_status()?;
+
+    let part_path = directory.join(format!("{}.part", required.filename));
+    let mut file = File::create(&part_path).await?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&part_path).await;
+                return Err(Box::new(e));
+            }
+        };
+        if let Err(e) = file.write_all(&chunk).await {
+            let _ = tokio::fs::remove_file(&part_path).await;
+            return Err(Box::new(e));
+        }
+    }
+    file.flush().await?;
+    drop(file);
+
+    // Verify the downloaded bytes match the expected hash before publishing.
+    let verify_path = part_path.clone();
+    let actual = tokio::task::spawn_blocking(move || Hash::compute_file(&verify_path)).await??;
+    if actual != required.xxhash64 {
+        let _ = tokio::fs::remove_file(&part_path).await;
+        return Err(format!(
+            "hash mismatch after download: expected {}, got {}",
+            required.xxhash64, actual
+        )
+        .into());
+    }
+
+    let final_path = directory.join(&required.filename);
+    tokio::fs::rename(&part_path, &final_path).await?;
+    Ok(())
 }
 
 /// Stream a single file up to the server. The caller is responsible for
@@ -541,6 +631,131 @@ async fn main() {
                     failed
                 );
             }
+        }
+
+        cli::Commands::FetchMods {
+            server,
+            directory,
+            modlist,
+            no_cache,
+            parallel,
+        } => {
+            if !directory.is_dir() {
+                log::error!("Download directory does not exist: {}", directory.display());
+                return;
+            }
+
+            let client = Client::new();
+            let server = match resolve_base_url(&client, server).await {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("Failed to reach server: {}", e);
+                    return;
+                }
+            };
+            let server = server.as_str();
+
+            let manifest = match fetch_modlist_manifest(&client, server, modlist).await {
+                Ok(Some(m)) => m,
+                Ok(None) => {
+                    log::error!("Modlist {} not found on the server", modlist);
+                    return;
+                }
+                Err(e) => {
+                    log::error!("Failed to fetch modlist info: {}", e);
+                    return;
+                }
+            };
+            log::info!(
+                "Modlist {} requires {} mods",
+                manifest.modlist_filename,
+                manifest.mods.len()
+            );
+
+            // Hash only the required mods that already exist locally (by their
+            // expected filename), so we never rehash the whole directory. The
+            // sync cache makes repeat runs cheap.
+            let existing_paths: Vec<PathBuf> = manifest
+                .mods
+                .iter()
+                .map(|m| directory.join(&m.filename))
+                .filter(|p| p.is_file())
+                .collect();
+
+            let hashing::HashResults {
+                hashed,
+                failed: hash_failed,
+            } = hash_files_with_cache(directory, existing_paths, !no_cache, (*parallel).max(1))
+                .await;
+
+            let mut local_hashes: HashMap<String, String> = HashMap::new();
+            for (path, hash) in hashed {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    local_hashes.insert(name.to_string(), hash);
+                }
+            }
+
+            let total = manifest.mods.len();
+            let mut downloaded = 0usize;
+            let mut present = 0usize;
+            let mut unavailable = 0usize;
+            let mut conflicts = 0usize;
+            let mut failed = hash_failed;
+
+            for (idx, required) in manifest.mods.iter().enumerate() {
+                let prefix = format!("[{}/{}]", idx + 1, total);
+
+                match local_hashes.get(&required.filename) {
+                    Some(hash) if hash == &required.xxhash64 => {
+                        log::debug!("{} {} already present", prefix, required.filename);
+                        present += 1;
+                        continue;
+                    }
+                    Some(_) => {
+                        // A different file occupies the expected name; don't
+                        // clobber it. Leave resolution to the user.
+                        log::warn!(
+                            "{} {} exists with a different hash — leaving it (delete it and re-run to refetch)",
+                            prefix,
+                            required.filename
+                        );
+                        conflicts += 1;
+                        continue;
+                    }
+                    None => {}
+                }
+
+                if !required.available {
+                    log::warn!(
+                        "{} {} is not archived on the server — cannot fetch",
+                        prefix,
+                        required.filename
+                    );
+                    unavailable += 1;
+                    continue;
+                }
+
+                log::info!("{} Fetching {}", prefix, required.filename);
+                match download_required_mod(&client, server, required, directory).await {
+                    Ok(()) => {
+                        log::info!("{} Fetched {}", prefix, required.filename);
+                        downloaded += 1;
+                    }
+                    Err(e) => {
+                        log::error!("{} Failed to fetch {}: {}", prefix, required.filename, e);
+                        failed += 1;
+                    }
+                }
+            }
+
+            log::info!(
+                "Fetch complete: {} downloaded, {} already present, {} unavailable, {} conflicts, {} errors",
+                downloaded,
+                present,
+                unavailable,
+                conflicts,
+                failed
+            );
         }
     }
 


### PR DESCRIPTION
## What

Adds a `fetch-mods` subcommand to `wabba-tools` that downloads every mod required by a modlist into a local downloads directory, skipping any already present.

```
wabba-tools fetch-mods <SERVER> <DIRECTORY> <MODLIST_XXHASH64> [--no-cache] [--parallel N]
```

### Behavior
- Resolves the modlist by hash and fetches its required-mods manifest from the server.
- For each required mod, looks for a local file under its **expected (per-modlist) filename**:
  - present with matching xxhash64 → **skipped**.
  - present with a **different** hash → reported and **left untouched** (never clobbered); delete it and re-run to refetch.
  - absent & archived on the server → **downloaded**.
  - absent & not archived on the server → reported as **unavailable** (can't fetch).
- Each download streams to a `.part` file, is **verified against its expected xxhash64**, then atomically renamed into place. A failed/mismatched download removes the temp file and is counted as an error.
- Ends with a summary: downloaded / already present / unavailable / conflicts / errors.

## Changes

**Server (`wabba-server`)**
- New `GET /modlist/mods` endpoint: given a modlist hash (via `If-None-Match`, matching `/check/*` and `/resolve`), returns each required mod's `id`, `xxhash64`, per-modlist `filename`, `size`, and `available` flag. `404` when the hash is not a known modlist.
- New joined query `Mod::get_with_filenames_by_modlist_id` pairs each required mod with the filename its modlist expects (the per-association name — the correct local download name, since a mod can be shared across modlists under different names).

**CLI (`wabba-tools`)**
- New `fetch-mods` subcommand.
- Reuses the shared `hashing` module to hash only the already-present candidates (not the whole directory), keeping repeat runs cheap via the existing `.wabba-sync-cache.json`.
- Added `futures-util` for streaming download bodies.

## Notes
- Mods download by id via the existing `GET /mod/{id}/download` route.
- Only `required_archives()` get modlist associations on ingest (game-file-source archives are excluded), so the manifest contains only genuinely downloadable mods.

## Testing
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo test` all clean across the workspace.
- Not yet verified end-to-end against a live server instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)