### PR TITLE
Redesign detail-page header cards with a cohesive hero + button system

### DIFF
--- a/wabba-protocol/src/archive_state.rs
+++ b/wabba-protocol/src/archive_state.rs
@@ -136,6 +136,30 @@ impl ArchiveState {
         }
     }
 
+    /// External URL where this archive can be found / downloaded from upstream,
+    /// if one applies. Used for the "Open Source" action on the mod details page.
+    pub fn source_url(&self) -> Option<String> {
+        match self {
+            ArchiveState::NexusDownloader {
+                game_name, mod_id, ..
+            } => Some(format!(
+                "https://www.nexusmods.com/{}/mods/{}",
+                game_name.to_lowercase().replace(' ', ""),
+                mod_id
+            )),
+            ArchiveState::HttpDownloader { url, .. } => Some(url.clone()),
+            ArchiveState::WabbajackCDNDownloader { url } => Some(url.clone()),
+            ArchiveState::ManualDownloader { url, .. } => Some(url.clone()),
+            ArchiveState::MegaDownloader { url } => Some(url.clone()),
+            ArchiveState::MediaFireDownloader { url } => Some(url.clone()),
+            ArchiveState::LoversLabOAuthDownloader { url, .. } => Some(url.clone()),
+            ArchiveState::GoogleDriveDownloader { id } => {
+                Some(format!("https://drive.google.com/file/d/{}/view", id))
+            }
+            ArchiveState::GameFileSourceDownloader { .. } | ArchiveState::UnknownDownloader => None,
+        }
+    }
+
     /// CSS class suffix used to colour the source chip (e.g. `nexus` -> `.source-chip.nexus`).
     pub fn source_chip_class(&self) -> &'static str {
         match self {

--- a/wabba-server/src/res/styles.css
+++ b/wabba-server/src/res/styles.css
@@ -333,14 +333,6 @@
     padding: 2rem;
   }
 
-  .header {
-    margin-bottom: 2rem;
-    background-color: white;
-    padding: 2rem;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-
   .back-link {
     display: inline-block;
     margin-bottom: 1rem;
@@ -354,36 +346,11 @@
     }
   }
 
-  h1 {
-    margin: 0 0 1rem 0;
-    color: #2c3e50;
-    font-size: 2rem;
-    font-weight: 600;
-  }
-
   h2 {
     margin: 2rem 0 1rem 0;
     color: #2c3e50;
     font-size: 1.5rem;
     font-weight: 600;
-  }
-
-  .metadata {
-    margin-top: 1rem;
-
-    p {
-      margin: 0.5rem 0;
-      color: #666;
-    }
-
-    strong {
-      color: #333;
-      font-weight: 600;
-    }
-
-    form {
-      margin-left: 0;
-    }
   }
 
   .source-section {
@@ -752,4 +719,177 @@
 
 .hash-copy.copied code::after {
   content: " ✓";
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Cohesive button system + detail-page hero card.
+   Colour semantics: blue = primary action, neutral outline = secondary,
+   red outline = destructive. Green/amber/red solids are reserved for status
+   badges only, so colour never means two different things.
+   ───────────────────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.btn-primary {
+  background-color: #2563eb;
+  color: #fff;
+}
+.btn-primary:hover {
+  background-color: #1d4ed8;
+}
+
+.btn-secondary {
+  background-color: #fff;
+  color: #334155;
+  border-color: #cbd5e1;
+}
+.btn-secondary:hover {
+  background-color: #f1f5f9;
+  border-color: #94a3b8;
+}
+
+.btn-danger {
+  background-color: #fff;
+  color: #b91c1c;
+  border-color: #fca5a5;
+}
+.btn-danger:hover {
+  background-color: #fef2f2;
+  border-color: #ef4444;
+}
+
+.status-badge.muted {
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.text-input {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.875rem;
+  min-width: 16rem;
+}
+.text-input:focus {
+  outline: none;
+  border-color: #2563eb;
+}
+
+/* Hero card at the top of detail pages. */
+.detail-hero {
+  margin-bottom: 2rem;
+  padding: 1.75rem;
+  background-color: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.hero-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-titleblock {
+  min-width: 0;
+}
+
+.hero-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #1e293b;
+}
+
+.hero-title .source-chip {
+  font-size: 0.8rem;
+  margin-left: 0;
+}
+
+.hero-filename {
+  margin-top: 0.4rem;
+  font-family: 'Courier New', monospace;
+  font-size: 0.85rem;
+  color: #64748b;
+  word-break: break-all;
+}
+
+.hero-status {
+  flex-shrink: 0;
+}
+
+.hero-status .status-badge {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.7rem;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1.25rem;
+}
+
+.hero-rename {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+/* Key-facts row beneath the actions. */
+.meta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid #eef2f7;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.meta-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.meta-value {
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.meta-value em {
+  color: #94a3b8;
+  font-style: italic;
 }

--- a/wabba-server/src/web/components.rs
+++ b/wabba-server/src/web/components.rs
@@ -96,15 +96,21 @@ pub fn modlist_identity_cell(href: &str, name: &str, filename: &str) -> Markup {
     identity_cell(href, name, secondary, None)
 }
 
-/// A hash cell rendering the full (short) hash on one line as a click-to-copy
-/// button — handy for pasting into CLI flags like `prune --keep <hash>`.
+/// A click-to-copy hash button (full hash, copies on click) — handy for
+/// pasting into CLI flags like `prune --keep <hash>`. Standalone so it can be
+/// used both in table cells and in the detail-page meta strips.
+pub fn hash_copy_button(hash: &str) -> Markup {
+    html! {
+        button.hash-copy type="button" data-hash=(hash) title="Click to copy full hash" {
+            code { (hash) }
+        }
+    }
+}
+
+/// A table cell wrapping [`hash_copy_button`].
 pub fn hash_cell(hash: &str) -> Markup {
     html! {
-        td.hash {
-            button.hash-copy type="button" data-hash=(hash) title="Click to copy full hash" {
-                code { (hash) }
-            }
-        }
+        td.hash { (hash_copy_button(hash)) }
     }
 }
 
@@ -121,7 +127,7 @@ document.addEventListener('click', function (e) {
   var text = btn.dataset.hash;
   try {
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text);
+      navigator.clipboard.writeText(text).catch(function () {});
     } else {
       var ta = document.createElement('textarea');
       ta.value = text;

--- a/wabba-server/src/web/details_page.rs
+++ b/wabba-server/src/web/details_page.rs
@@ -10,7 +10,7 @@ use crate::db::mod_association::ModAssociation;
 use crate::db::mod_data::Mod;
 use crate::db::modlist::Modlist;
 use crate::web::components::{
-    clipboard_script, colgroup, hash_cell, mod_identity_cell, modlist_identity_cell,
+    clipboard_script, colgroup, hash_cell, hash_copy_button, mod_identity_cell, modlist_identity_cell,
 };
 use wabba_protocol::archive_state::ArchiveState;
 
@@ -30,14 +30,6 @@ fn format_size(bytes: u64) -> String {
     }
 }
 
-fn format_hash(hash: &str) -> String {
-    if hash.len() > 16 {
-        format!("{}...", &hash[..16])
-    } else {
-        hash.to_string()
-    }
-}
-
 fn nexus_game_url_slug(game_name: &str) -> String {
     game_name.to_lowercase().replace(" ", "")
 }
@@ -48,7 +40,6 @@ fn render_source(source: &ArchiveState, mod_id: u64) -> maud::Markup {
             ArchiveState::NexusDownloader {
                 name,
                 mod_id,
-                file_id,
                 game_name,
                 author,
                 description,
@@ -88,22 +79,6 @@ fn render_source(source: &ArchiveState, mod_id: u64) -> maud::Markup {
                         div.source-field {
                             strong { "Version: " }
                             (version)
-                        }
-                        div.source-field {
-                            strong { "Game: " }
-                            (game_name)
-                        }
-                        div.source-field {
-                            strong { "Mod ID: " }
-                            a href=(format!("https://www.nexusmods.com/{}/mods/{}", game_slug, mod_id)) target="_blank" {
-                                code { (mod_id) }
-                            }
-                        }
-                        div.source-field {
-                            strong { "File ID: " }
-                            a href=(format!("https://www.nexusmods.com/{}/mods/{}?tab=files&file_id={}", game_slug, mod_id, file_id)) target="_blank" {
-                                code { (file_id) }
-                            }
                         }
                         @if !description.is_empty() {
                             div.source-field {
@@ -206,7 +181,6 @@ fn render_source(source: &ArchiveState, mod_id: u64) -> maud::Markup {
             }
             ArchiveState::LoversLabOAuthDownloader {
                 name,
-                ips4_mod,
                 url,
                 author,
                 description,
@@ -247,10 +221,6 @@ fn render_source(source: &ArchiveState, mod_id: u64) -> maud::Markup {
                                 strong { "Version: " }
                                 (mod_version)
                             }
-                        }
-                        div.source-field {
-                            strong { "Mod ID: " }
-                            code { (ips4_mod) }
                         }
                         div.source-field {
                             strong { "URL: " }
@@ -410,6 +380,22 @@ pub async fn mod_details_page(
         Vec::new()
     };
 
+    // Hero card display values: lead with the upstream mod name, fall back to
+    // the filename (which becomes the title when there is no name).
+    let hero_name = primary_assoc
+        .and_then(|a| a.name.as_deref())
+        .filter(|s| !s.is_empty());
+    let hero_filename = mod_item
+        .disk_filename
+        .as_deref()
+        .or_else(|| primary_assoc.map(|a| a.filename.as_str()))
+        .filter(|s| !s.is_empty());
+    let hero_title = hero_name.or(hero_filename).unwrap_or("Unknown Mod");
+    let hero_subline = if hero_name.is_some() { hero_filename } else { None };
+    let source_url = primary_assoc.and_then(|a| a.source.source_url());
+    let source_chip =
+        primary_assoc.map(|a| (a.source.source_chip_label(), a.source.source_chip_class()));
+
     let page = html! {
         (maud::DOCTYPE)
         html {
@@ -453,65 +439,21 @@ pub async fn mod_details_page(
             }
             body.page-details {
                 div.container {
-                    div.header {
-                        a.back-link href="/" { "← Back to Modlists" }
-                        h1 {
-                            @match primary_assoc {
-                                Some(assoc) => {
-                                    @match &assoc.name {
-                                        Some(name) => {
-                                            (name.clone())
-                                        }
-                                        None => {
-                                            @match &mod_item.disk_filename {
-                                                Some(disk_filename) => {
-                                                    (disk_filename.clone())
-                                                }
-                                                None => {
-                                                    (assoc.filename.clone())
-                                                }
-                                            }
-                                        }
+                    div.detail-hero {
+                        a.back-link href="/mods" { "← All Mods" }
+                        div.hero-head {
+                            div.hero-titleblock {
+                                h1.hero-title {
+                                    (hero_title)
+                                    @if let Some((label, class)) = source_chip {
+                                        span class=(format!("source-chip {class}")) { (label) }
                                     }
                                 }
-                                None => {
-                                    @match &mod_item.disk_filename {
-                                        Some(disk_filename) => {
-                                            (disk_filename.clone())
-                                        }
-                                        None => {
-                                            "Unknown Mod"
-                                        }
-                                    }
+                                @if let Some(sub) = hero_subline {
+                                    div.hero-filename { (sub) }
                                 }
                             }
-                        }
-                        div.metadata {
-                            p { strong { "ID: " } (mod_item.id) }
-                            p {
-                                strong { "Disk Filename: " }
-                                @match &mod_item.disk_filename {
-                                    Some(disk_filename) => {
-                                        (disk_filename.clone())
-                                    }
-                                    None => {
-                                        em { "Not available on disk" }
-                                    }
-                                }
-                            }
-                            @if let Some(assoc) = primary_assoc {
-                                p { strong { "Modlist Filename: " } (assoc.filename.clone()) }
-                        @if let Some(name) = &assoc.name {
-                            p { strong { "Name: " } (name.clone()) }
-                        }
-                        @if let Some(version) = &assoc.version {
-                            p { strong { "Version: " } (version.clone()) }
-                        }
-                            }
-                            p { strong { "Size: " } (format_size(mod_item.size)) }
-                            p { strong { "Hash: " } span.hash { code { (format_hash(&mod_item.xxhash64)) } } }
-                            p {
-                                strong { "Status: " }
+                            div.hero-status {
                                 @if mod_item.is_available() {
                                     span.status-badge.available { "Available" }
                                 } @else if mod_item.lost_forever {
@@ -519,43 +461,49 @@ pub async fn mod_details_page(
                                 } @else {
                                     span.status-badge.unavailable { "Unavailable" }
                                 }
-                                @if mod_item.is_available() {
-                                    a.download-button href=(format!("/mod/{}/download", mod_item.id)) style="display: inline-block; margin-left: 1rem; padding: 0.4rem 0.8rem; border-radius: 4px; background-color: #27ae60; color: white; font-weight: 500; text-decoration: none;" {
-                                        "Download"
-                                    }
-                                }
                             }
-                            @if !mod_item.is_available() {
-                                p {
-                                    strong { "Lost Forever: " }
-                                    @if mod_item.lost_forever {
-                                        span.status-badge.missing { "Yes" }
-                                    } @else {
-                                        span { "No" }
-                                    }
-                                    form method="post" action=(format!("/mod/{}/toggle-lost-forever", mod_item.id)) style="display: inline-block;" {
-                                        button type="submit" style="padding: 0.4rem 0.8rem; border-radius: 4px; border: none; cursor: pointer; background-color: #3498db; color: white; font-weight: 500;" {
-                                            @if mod_item.lost_forever {
-                                                "Mark as Recoverable"
-                                            } @else {
-                                                "Mark as Lost Forever"
-                                            }
-                                        }
+                        }
+                        div.hero-actions {
+                            @if mod_item.is_available() {
+                                a.btn.btn-primary href=(format!("/mod/{}/download", mod_item.id)) { "↓ Download" }
+                                @if let Some(url) = &source_url {
+                                    a.btn.btn-secondary href=(url) target="_blank" rel="noopener" { "Open Source ↗" }
+                                }
+                            } @else {
+                                @if let Some(url) = &source_url {
+                                    a.btn.btn-primary href=(url) target="_blank" rel="noopener" { "Open Source ↗" }
+                                }
+                                form method="post" action=(format!("/mod/{}/toggle-lost-forever", mod_item.id)) {
+                                    button.btn.btn-secondary type="submit" {
+                                        @if mod_item.lost_forever { "Mark as Recoverable" } @else { "Mark as Lost Forever" }
                                     }
                                 }
                             }
                             @if show_debug {
-                                p.debug-actions style="margin-top: 1rem; padding-top: 1rem; border-top: 1px dashed #e74c3c;" {
-                                    strong { "Debug: " }
-                                    form method="post"
-                                         action=(format!("/mod/{}/delete", mod_item.id))
-                                         onsubmit="return confirm('Delete this mod permanently?\\n\\nThis removes the DB row, all mod associations, and the file on disk. Cannot be undone.');"
-                                         style="display: inline-block;" {
-                                        button type="submit" style="padding: 0.4rem 0.8rem; border-radius: 4px; border: none; cursor: pointer; background-color: #e74c3c; color: white; font-weight: 500;" {
-                                            "Delete Mod"
-                                        }
+                                form method="post"
+                                     action=(format!("/mod/{}/delete", mod_item.id))
+                                     onsubmit="return confirm('Delete this mod permanently?\\n\\nThis removes the DB row, all mod associations, and the file on disk. Cannot be undone.');" {
+                                    button.btn.btn-danger type="submit" { "Delete Mod" }
+                                }
+                            }
+                        }
+                        div.meta-strip {
+                            div.meta-item {
+                                span.meta-label { "Version" }
+                                span.meta-value {
+                                    @match primary_assoc.and_then(|a| a.version.as_deref()) {
+                                        Some(v) if !v.is_empty() => { (v) }
+                                        _ => { em { "—" } }
                                     }
                                 }
+                            }
+                            div.meta-item {
+                                span.meta-label { "Size" }
+                                span.meta-value { (format_size(mod_item.size)) }
+                            }
+                            div.meta-item {
+                                span.meta-label { "Hash" }
+                                span.meta-value { (hash_copy_button(&mod_item.xxhash64)) }
                             }
                         }
                     }
@@ -1163,6 +1111,11 @@ pub async fn details_page(
         })
         .collect();
 
+    // Modlist install-readiness summary for the hero status badge.
+    let mods_total = mods.len();
+    let mods_available = mods_total - unavailable_mods.len();
+    let has_lost_forever = unavailable_mods.iter().any(|m| m.lost_forever);
+
     let page = html! {
         (maud::DOCTYPE)
         html {
@@ -1175,63 +1128,69 @@ pub async fn details_page(
             }
             body.page-details {
                 div.container {
-                    div.header {
+                    div.detail-hero {
                         a.back-link href=(if modlist.muted { "/modlists/muted" } else { "/" }) {
                             @if modlist.muted {
-                                "← Back to Muted Modlists"
+                                "← Muted Modlists"
                             } @else {
-                                "← Back to Modlists"
+                                "← All Modlists"
                             }
                         }
-                        h1 { (modlist.name.clone()) }
-                        div.metadata {
-                            p { strong { "Version: " } (modlist.version.clone()) }
-                            p {
-                                strong { "Filename: " }
-                                (modlist.filename.clone())
-                                form method="post" action=(format!("/modlists/{}/rename", modlist.id)) style="display: inline-block; margin-left: 1rem;" {
-                                    input type="text" name="new_filename" value=(modlist.filename.clone()) style="padding: 0.4rem; border: 1px solid #ccc; border-radius: 4px; margin-right: 0.5rem;" required;
-                                    button type="submit" style="padding: 0.4rem 0.8rem; border-radius: 4px; border: none; cursor: pointer; background-color: #27ae60; color: white; font-weight: 500;" {
-                                        "Rename"
-                                    }
+                        div.hero-head {
+                            div.hero-titleblock {
+                                h1.hero-title { (modlist.name.clone()) }
+                                div.hero-filename { (modlist.filename.clone()) }
+                            }
+                            div.hero-status {
+                                @if has_lost_forever {
+                                    span.status-badge.missing { "Uninstallable" }
+                                } @else if mods_available < mods_total {
+                                    span.status-badge.unavailable { "Missing files" }
+                                } @else {
+                                    span.status-badge.available { "Ready" }
                                 }
-                                @if modlist.available {
-                                    a.download-button href=(format!("/modlists/{}/download", modlist.id)) style="display: inline-block; margin-left: 0.5rem; padding: 0.4rem 0.8rem; border-radius: 4px; background-color: #27ae60; color: white; font-weight: 500; text-decoration: none;" {
-                                        "Download"
-                                    }
+                                @if modlist.muted {
+                                    span.status-badge.muted { "Muted" }
                                 }
                             }
-                            p { strong { "Size: " } (format_size(modlist.size)) }
-                            p { strong { "Hash: " } span.hash { code { (format_hash(&modlist.xxhash64)) } } }
-                            p {
-                                strong { "Muted: " }
-                                @if modlist.muted {
-                                    span.status-badge.missing { "Yes" }
-                                } @else {
-                                    span { "No" }
+                        }
+                        div.hero-actions {
+                            @if modlist.available {
+                                a.btn.btn-primary href=(format!("/modlists/{}/download", modlist.id)) { "↓ Download" }
+                            }
+                            form method="post" action=(format!("/modlists/{}/toggle-muted", modlist.id)) {
+                                button.btn.btn-secondary type="submit" {
+                                    @if modlist.muted { "Unmute" } @else { "Mute" }
                                 }
-                                form method="post" action=(format!("/modlists/{}/toggle-muted", modlist.id)) style="display: inline-block;" {
-                                    button type="submit" style="padding: 0.4rem 0.8rem; border-radius: 4px; border: none; cursor: pointer; background-color: #3498db; color: white; font-weight: 500;" {
-                                        @if modlist.muted {
-                                            "Unmute Modlist"
-                                        } @else {
-                                            "Mute Modlist"
-                                        }
-                                    }
-                                }
+                            }
+                            form.hero-rename method="post" action=(format!("/modlists/{}/rename", modlist.id)) {
+                                input.text-input type="text" name="new_filename" value=(modlist.filename.clone()) required;
+                                button.btn.btn-secondary type="submit" { "Rename" }
                             }
                             @if show_debug {
-                                p.debug-actions style="margin-top: 1rem; padding-top: 1rem; border-top: 1px dashed #e74c3c;" {
-                                    strong { "Debug: " }
-                                    form method="post"
-                                         action=(format!("/modlists/{}/delete", modlist.id))
-                                         onsubmit="return confirm('Delete this modlist permanently?\\n\\nThis removes the DB row, all mod associations, and the .wabbajack file on disk. Mods referenced only by this modlist remain. Cannot be undone.');"
-                                         style="display: inline-block;" {
-                                        button type="submit" style="padding: 0.4rem 0.8rem; border-radius: 4px; border: none; cursor: pointer; background-color: #e74c3c; color: white; font-weight: 500;" {
-                                            "Delete Modlist"
-                                        }
-                                    }
+                                form method="post"
+                                     action=(format!("/modlists/{}/delete", modlist.id))
+                                     onsubmit="return confirm('Delete this modlist permanently?\\n\\nThis removes the DB row, all mod associations, and the .wabbajack file on disk. Mods referenced only by this modlist remain. Cannot be undone.');" {
+                                    button.btn.btn-danger type="submit" { "Delete Modlist" }
                                 }
+                            }
+                        }
+                        div.meta-strip {
+                            div.meta-item {
+                                span.meta-label { "Version" }
+                                span.meta-value { (modlist.version.clone()) }
+                            }
+                            div.meta-item {
+                                span.meta-label { "Size" }
+                                span.meta-value { (format_size(modlist.size)) }
+                            }
+                            div.meta-item {
+                                span.meta-label { "Mods" }
+                                span.meta-value { (mods_available) " / " (mods_total) }
+                            }
+                            div.meta-item {
+                                span.meta-label { "Hash" }
+                                span.meta-value { (hash_copy_button(&modlist.xxhash64)) }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

The header cards on the mod- and modlist-detail pages were inconsistent — flat `label: value` lists, inline-styled buttons of varying sizes/fonts, and colour used to mean different things (green for both "available" and "download", red for both "lost forever" and "delete"). This replaces them with one cohesive **hero card** and a shared button system.

### Hero card
- **Identity row:** bold title + source chip, with a single **status badge** pinned top-right.
- **Filename subline** in muted monospace.
- **Action bar** ordered by what the user actually needs, using one button system.
- **Meta strip** of key facts: Version · Size · Hash (click-to-copy); modlists also show Mods available/total.
- Dropped noise: mod ID, the redundant Disk-vs-Modlist filename pair, and the name that just duplicated the title.

### Cohesive colour semantics
- **Blue** = primary action, **neutral outline** = secondary, **red outline** = destructive.
- **Green/amber/red solids** are now reserved exclusively for status badges, so a colour never means two things.

### Action priority (mod file)
- **Available:** `↓ Download` (primary) + `Open Source ↗`.
- **Unavailable:** `Open Source ↗` (primary — how to get it) + `Mark Lost Forever / Recoverable`.
- Modlist: `↓ Download` + `Mute/Unmute` + `Rename`, and a real status badge (Ready / Missing files / Uninstallable, plus a Muted chip).

### Other
- `ArchiveState::source_url()` powers the new "Open Source" link.
- **Source card** kept (header + hero image + author/name/version/description as requested) but trimmed of game / mod id / file id noise.
- Extracted `hash_copy_button` so the meta strips and tables share one copyable-hash component.

## Testing
- `cargo build` + `cargo clippy` clean, no warnings.
- Validated in-browser against the prod-DB copy: available Nexus mod, lost-forever LoversLab mod, modlist with missing files, and a muted/uninstallable modlist. Confirmed status badges, action routing, meta strip, and click-to-copy hash all render correctly with no overflow or console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)